### PR TITLE
Fix ErrTxTypeNotSupported in TestIsthmusInitiateWithdrawal

### DIFF
--- a/kurtosis/mvp_test.go
+++ b/kurtosis/mvp_test.go
@@ -40,7 +40,7 @@ func TestIsthmusInitiateWithdrawal(t *testing.T) {
 			require.NoError(t, err)
 
 			// Ugly code for signing transactions
-			signer := types.NewEIP155Signer(chain.ID())
+			signer := types.NewLondonSigner(chain.ID())
 			signerFn := func(address common.Address, tx *types.Transaction) (*types.Transaction, error) {
 				return types.SignTx(tx, signer, user.PrivateKey())
 			}
@@ -90,8 +90,8 @@ func TestIsthmusInitiateWithdrawal(t *testing.T) {
 			mintTx, err := erc20.Mint(&bind.TransactOpts{
 				Signer:    signerFn,
 				From:      user.Address(),
-				GasFeeCap: big.NewInt(200),
-				GasTipCap: big.NewInt(100),
+				GasFeeCap: block.BaseFee(),
+				GasTipCap: tipCap,
 			}, user.Address(), big.NewInt(9000000000))
 			require.NoError(t, err)
 


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

Small PR to fix signer issue that was causing transactions to be rejected by go-ethereum/client. TestIsthmusInitiateWithdrawal is still failing with `execution reverted` but without any additional context.

<!--
A clear and concise description of the features you're adding in this pull request.
-->

**Tests**

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

N/A

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
